### PR TITLE
 Fix - Changing the summary to 0 - 0 of 0 if no users are present

### DIFF
--- a/addon/components/models-table.js
+++ b/addon/components/models-table.js
@@ -703,6 +703,12 @@ export default Component.extend({
       firstIndex,
       lastIndex
     } = getProperties(this, 'arrangedContentLength', 'firstIndex', 'lastIndex');
+    /**
+     * Send the values as 0 if the no users are fetched
+     */
+    if(arrangedContentLength === 0 ){
+      return fmt(get(this, 'messages.tableSummary'), 0, 0, 0);
+    }
     return fmt(get(this, 'messages.tableSummary'), firstIndex, lastIndex, arrangedContentLength);
   }),
 


### PR DESCRIPTION
Context: 

This PR changes the value of the first index to 0 if the no users are fetched from the database. 